### PR TITLE
修复recyclerview中展开侧滑菜单后滑动列表出现item偏移量异常的问题

### DIFF
--- a/SwipeItem/app/src/main/java/com/nalan/swipeitem/recyclerview/SwipeItemLayout-2017-10-23.java
+++ b/SwipeItem/app/src/main/java/com/nalan/swipeitem/recyclerview/SwipeItemLayout-2017-10-23.java
@@ -199,6 +199,7 @@ public class SwipeItemLayout extends ViewGroup {
         super.onDetachedFromWindow();
         removeCallbacks(scrollRunnable);
         touchMode = Mode.RESET;
+        offsetChildrenLeftAndRight(-scrollOffset);
         scrollOffset = 0;
     }
 


### PR DESCRIPTION
在recyclerview中使用该布局后，当item处于侧滑展开状态，滑动Item后调用onDetachedFromWindow后，视图对应的offset依然为scrollOffset，导致item复用后处于侧滑展开状态，但是SwipeItemLayout中scrollOffset被置为0，所以item已经处于展开状态但是只能继续左滑。

重置状态时应该同时重置变量scrollOffset以及视图的offset。